### PR TITLE
Add basic support for chunked transfer-encoding responses

### DIFF
--- a/ANSIC.lby
+++ b/ANSIC.lby
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?AutomationStudio FileVersion="4.9"?>
-<Library Version="0.01.2" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
+<Library Version="0.01.3" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
   <Files>
     <File>README.md</File>
     <File>LICENSE.md</File>

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2021 Loupe
+Copyright 2023 Loupe
 
 This software is licensed under the Loupe Software License Agreement.
 Please contact Loupe for information at info@loupe.team or 1-800-240-7042.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ info@loupe.team
 
 ## Change log
 
+ - 0.01.3 - Add basic support for chunked transfer-encoding responses
+
  - 0.01.2 - Add support for HTTPS
 
  - 0.01.1 - Fix memory overrun and partial packets


### PR DESCRIPTION
- The library will now process the body of the response where the transfer-encoding=chunked, even when content-length header is missing.
- Note that no packet reassembly has been implemented for chunks.